### PR TITLE
docs: update Expo setup guide link

### DIFF
--- a/expo-app/README.md
+++ b/expo-app/README.md
@@ -1,1 +1,1 @@
-See the [Expo setup guide](https://preview.livestore.dev/getting-started/expo).
+See the [Expo setup guide](https://livestore.dev/getting-started/expo).


### PR DESCRIPTION
The current URL points to https://preview.livestore.dev/getting-started/expo which is not available. Accessing the same link without the preview prefix opens up the correct expo setup page.